### PR TITLE
Switch to f-strings (and remove support for Python 3.5.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,8 @@ https://pollen.com, https://flustar.com, and more).
 
 `pyiqvia` is currently supported on:
 
-* Python 3.5
 * Python 3.6
 * Python 3.7
-
-However, running the test suite currently requires Python 3.6 or higher; tests
-run on Python 3.5 will fail.
 
 # Installation
 

--- a/example.py
+++ b/example.py
@@ -17,7 +17,7 @@ async def run(websession):
     """Run."""
     try:
         client = Client("17015", websession)
-        print('Client instantiated for ZIP "{0}"'.format(client.zip_code))
+        print(f'Client instantiated for ZIP "{client.zip_code}"')
 
         print()
         print("Allergen Data:")

--- a/pyiqvia/client.py
+++ b/pyiqvia/client.py
@@ -26,7 +26,7 @@ class Client:  # pylint: disable=too-few-public-methods
     def __init__(self, zip_code: str, websession: ClientSession) -> None:
         """Initialize."""
         if not is_valid_zip_code(zip_code):
-            raise InvalidZipError("Invalid ZIP code: {0}".format(zip_code))
+            raise InvalidZipError(f"Invalid ZIP code: {zip_code}")
 
         self._websession = websession
         self.zip_code = zip_code
@@ -42,10 +42,9 @@ class Client:  # pylint: disable=too-few-public-methods
         *,
         headers: dict = None,
         params: dict = None,
-        json: dict = None
+        json: dict = None,
     ) -> dict:
         """Make a request against AirVisual."""
-        full_url = "{0}/{1}".format(url, self.zip_code)
         pieces = urlparse(url)
 
         if not headers:
@@ -53,19 +52,17 @@ class Client:  # pylint: disable=too-few-public-methods
         headers.update(
             {
                 "Content-Type": "application/json",
-                "Referer": "{0}://{1}".format(pieces.scheme, pieces.netloc),
+                "Referer": f"{pieces.scheme}://{pieces.netloc}",
                 "User-Agent": API_USER_AGENT,
             }
         )
 
         async with self._websession.request(
-            method, full_url, headers=headers, params=params, json=json
+            method, f"{url}/{self.zip_code}", headers=headers, params=params, json=json
         ) as resp:
             try:
                 resp.raise_for_status()
                 data = await resp.json(content_type=None)
                 return data
             except client_exceptions.ClientError as err:
-                raise RequestError(
-                    "Error requesting data from {0}: {1}".format(url, err)
-                )
+                raise RequestError(f"Error requesting data from {url}: {err}")

--- a/setup.py
+++ b/setup.py
@@ -13,17 +13,17 @@ from shutil import rmtree
 from setuptools import find_packages, setup, Command
 
 # Package meta-data.
-NAME = 'pyiqvia'
-DESCRIPTION = 'A clean, async-focused Python3 API for IQVIA data'
-URL = 'https://github.com/bachya/pyiqvia'
-EMAIL = 'bachya1208@gmail.com'
-AUTHOR = 'Aaron Bach'
-REQUIRES_PYTHON = '>=3.5.3'
+NAME = "pyiqvia"
+DESCRIPTION = "A clean, async-focused Python3 API for IQVIA data"
+URL = "https://github.com/bachya/pyiqvia"
+EMAIL = "bachya1208@gmail.com"
+AUTHOR = "Aaron Bach"
+REQUIRES_PYTHON = ">=3.6.0"
 VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [  # type: ignore
-    'aiohttp'
+    "aiohttp"
 ]
 
 # The rest you shouldn't have to touch too much :)
@@ -36,28 +36,28 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
-with io.open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
-    LONG_DESC = '\n' + f.read()
+with io.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
+    LONG_DESC = "\n" + f.read()
 
 # Load the package's __version__.py module as a dictionary.
 ABOUT = {}  # type: ignore
 if not VERSION:
-    with open(os.path.join(HERE, NAME, 'const.py')) as f:
+    with open(os.path.join(HERE, NAME, "__version__.py")) as f:
         exec(f.read(), ABOUT)  # pylint: disable=exec-used
 else:
-    ABOUT['__version__'] = VERSION
+    ABOUT["__version__"] = VERSION
 
 
 class UploadCommand(Command):
     """Support setup.py upload."""
 
-    description = 'Build and publish the package.'
+    description = "Build and publish the package."
     user_options = []  # type: ignore
 
     @staticmethod
     def status(string):
-        """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(string))
+        """Print things in bold."""
+        print(f"\033[1m{string}\033[0m")
 
     def initialize_options(self):
         """Add options for initialization."""
@@ -70,22 +70,20 @@ class UploadCommand(Command):
     def run(self):
         """Run."""
         try:
-            self.status('Removing previous builds…')
-            rmtree(os.path.join(HERE, 'dist'))
+            self.status("Removing previous builds…")
+            rmtree(os.path.join(HERE, "dist"))
         except OSError:
             pass
 
-        self.status('Building Source and Wheel (universal) distribution…')
-        os.system(
-            '{0} setup.py sdist bdist_wheel --universal'.format(
-                sys.executable))
+        self.status("Building Source and Wheel (universal) distribution…")
+        os.system(f"{sys.executable} setup.py sdist bdist_wheel --universal")
 
-        self.status('Uploading the package to PyPi via Twine…')
-        os.system('twine upload dist/*')
+        self.status("Uploading the package to PyPi via Twine…")
+        os.system("twine upload dist/*")
 
-        self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(ABOUT['__version__']))
-        os.system('git push --tags')
+        self.status("Pushing git tags…")
+        os.system(f"git tag v{ABOUT['__version__']}")
+        os.system("git push --tags")
 
         sys.exit()
 
@@ -93,38 +91,34 @@ class UploadCommand(Command):
 # Where the magic happens:
 setup(
     name=NAME,
-    version=ABOUT['__version__'],
+    version=ABOUT["__version__"],
     description=DESCRIPTION,
     long_description=LONG_DESC,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author=AUTHOR,
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    packages=find_packages(exclude=('tests', )),
+    packages=find_packages(exclude=("tests",)),
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
-
     # entry_points={
     #     'console_scripts': ['mycli=mymodule:cli'],
     # },
     install_requires=REQUIRED,
     include_package_data=True,
-    license='MIT',
+    license="MIT",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy'
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     # $ setup.py publish support.
-    cmdclass={
-        'upload': UploadCommand,
-    },
+    cmdclass={"upload": UploadCommand},
 )

--- a/tests/test_allergens.py
+++ b/tests/test_allergens.py
@@ -17,7 +17,7 @@ async def test_current(aresponses, event_loop, fixture_current):
     """Test getting current allergen data."""
     aresponses.add(
         "www.pollen.com",
-        "/api/forecast/current/pollen/{0}".format(TEST_ZIP),
+        f"/api/forecast/current/pollen/{TEST_ZIP}",
         "get",
         aresponses.Response(text=json.dumps(fixture_current), status=200),
     )
@@ -34,7 +34,7 @@ async def test_extended(aresponses, event_loop, fixture_extended):
     """Test getting extended allergen info."""
     aresponses.add(
         "www.pollen.com",
-        "/api/forecast/extended/pollen/{0}".format(TEST_ZIP),
+        f"/api/forecast/extended/pollen/{TEST_ZIP}",
         "get",
         aresponses.Response(text=json.dumps(fixture_extended), status=200),
     )
@@ -51,7 +51,7 @@ async def test_historic(aresponses, event_loop, fixture_historic):
     """Test getting historic allergen info."""
     aresponses.add(
         "www.pollen.com",
-        "/api/forecast/historic/pollen/{0}".format(TEST_ZIP),
+        f"/api/forecast/historic/pollen/{TEST_ZIP}",
         "get",
         aresponses.Response(text=json.dumps(fixture_historic), status=200),
     )
@@ -68,7 +68,7 @@ async def test_outlook(aresponses, event_loop, fixture_outlook):
     """Test getting outlook allergen info."""
     aresponses.add(
         "www.pollen.com",
-        "/api/forecast/outlook/{0}".format(TEST_ZIP),
+        f"/api/forecast/outlook/{TEST_ZIP}",
         "get",
         aresponses.Response(text=json.dumps(fixture_outlook), status=200),
     )

--- a/tests/test_asthma.py
+++ b/tests/test_asthma.py
@@ -17,7 +17,7 @@ async def test_current(aresponses, event_loop, fixture_current):
     """Test getting current asthma."""
     aresponses.add(
         "www.asthmaforecast.com",
-        "/api/forecast/current/asthma/{0}".format(TEST_ZIP),
+        f"/api/forecast/current/asthma/{TEST_ZIP}",
         "get",
         aresponses.Response(text=json.dumps(fixture_current), status=200),
     )
@@ -34,7 +34,7 @@ async def test_extended(aresponses, event_loop, fixture_extended):
     """Test getting extended asthma info."""
     aresponses.add(
         "www.asthmaforecast.com",
-        "/api/forecast/extended/asthma/{0}".format(TEST_ZIP),
+        f"/api/forecast/extended/asthma/{TEST_ZIP}",
         "get",
         aresponses.Response(text=json.dumps(fixture_extended), status=200),
     )
@@ -51,7 +51,7 @@ async def test_endpoints(aresponses, event_loop, fixture_historic):
     """Test getting historic asthma info."""
     aresponses.add(
         "www.asthmaforecast.com",
-        "/api/forecast/historic/asthma/{0}".format(TEST_ZIP),
+        f"/api/forecast/historic/asthma/{TEST_ZIP}",
         "get",
         aresponses.Response(text=json.dumps(fixture_historic), status=200),
     )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,7 +24,7 @@ async def test_bad_zip(event_loop):
     """Test attempting to create a client with a bad ZIP code."""
     with pytest.raises(InvalidZipError):
         async with aiohttp.ClientSession(loop=event_loop) as websession:
-            client = Client(TEST_BAD_ZIP, websession)
+            _ = Client(TEST_BAD_ZIP, websession)
 
 
 @pytest.mark.asyncio
@@ -32,13 +32,13 @@ async def test_request_error(aresponses, event_loop):
     """Test authenticating the device."""
     aresponses.add(
         "www.pollen.com",
-        "/api/bad_endpoint/{0}".format(TEST_ZIP),
+        f"/api/bad_endpoint/{TEST_ZIP}",
         "get",
         aresponses.Response(text="", status=404),
     )
     aresponses.add(
         "www.pollen.com",
-        "/api/forecast/outlook/{0}".format(TEST_ZIP),
+        f"/api/forecast/outlook/{TEST_ZIP}",
         "get",
         aresponses.Response(text="", status=500),
     )

--- a/tests/test_disease.py
+++ b/tests/test_disease.py
@@ -17,7 +17,7 @@ async def test_current(aresponses, event_loop, fixture_current):
     """Test getting current cold and flu data."""
     aresponses.add(
         "www.flustar.com",
-        "/api/forecast/current/cold/{0}".format(TEST_ZIP),
+        f"/api/forecast/current/cold/{TEST_ZIP}",
         "get",
         aresponses.Response(text=json.dumps(fixture_current), status=200),
     )
@@ -34,7 +34,7 @@ async def test_extended(aresponses, event_loop, fixture_extended):
     """Test getting extended cold and flu data."""
     aresponses.add(
         "www.pollen.com",
-        "/api/forecast/extended/cold/{0}".format(TEST_ZIP),
+        f"/api/forecast/extended/cold/{TEST_ZIP}",
         "get",
         aresponses.Response(text=json.dumps(fixture_extended), status=200),
     )
@@ -51,7 +51,7 @@ async def test_historic(aresponses, event_loop, fixture_historic):
     """Test getting historic cold and flu data."""
     aresponses.add(
         "www.flustar.com",
-        "/api/forecast/historic/cold/{0}".format(TEST_ZIP),
+        f"/api/forecast/historic/cold/{TEST_ZIP}",
         "get",
         aresponses.Response(text=json.dumps(fixture_historic), status=200),
     )


### PR DESCRIPTION
**Describe what the PR does:**

This PR drops runtime support for Python 3.5.3 and makes the minimum runtime version 3.6. One of a few benefits to follow: we now get to use f-strings.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
