### PR TITLE
Add Python 3.6-style variable type annotations

### DIFF
--- a/pyiqvia/allergens.py
+++ b/pyiqvia/allergens.py
@@ -7,7 +7,7 @@ class Allergens:
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def current(self) -> dict:
         """Get current allergy conditions."""

--- a/pyiqvia/asthma.py
+++ b/pyiqvia/asthma.py
@@ -7,7 +7,7 @@ class Asthma:  # pylint: disable=too-few-public-methods
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def current(self) -> dict:
         """Get current asthma info."""

--- a/pyiqvia/client.py
+++ b/pyiqvia/client.py
@@ -1,5 +1,6 @@
 """Define a client to interact with Pollen.com."""
-from urllib.parse import urlparse
+from typing import Optional
+from urllib.parse import ParseResult, urlparse
 
 from aiohttp import ClientSession, client_exceptions
 
@@ -8,7 +9,7 @@ from .asthma import Asthma
 from .disease import Disease
 from .errors import InvalidZipError, RequestError
 
-API_USER_AGENT = (
+API_USER_AGENT: str = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) "
     + "AppleWebKit/537.36 (KHTML, like Gecko) "
     + "Chrome/65.0.3325.181 Safari/537.36"
@@ -28,24 +29,24 @@ class Client:  # pylint: disable=too-few-public-methods
         if not is_valid_zip_code(zip_code):
             raise InvalidZipError(f"Invalid ZIP code: {zip_code}")
 
-        self._websession = websession
-        self.zip_code = zip_code
+        self._websession: ClientSession = websession
+        self.zip_code: str = zip_code
 
-        self.allergens = Allergens(self._request)
-        self.asthma = Asthma(self._request)
-        self.disease = Disease(self._request)
+        self.allergens: Allergens = Allergens(self._request)
+        self.asthma: Asthma = Asthma(self._request)
+        self.disease: Disease = Disease(self._request)
 
     async def _request(
         self,
         method: str,
         url: str,
         *,
-        headers: dict = None,
-        params: dict = None,
-        json: dict = None,
+        headers: Optional[dict] = None,
+        params: Optional[dict] = None,
+        json: Optional[dict] = None,
     ) -> dict:
         """Make a request against AirVisual."""
-        pieces = urlparse(url)
+        pieces: ParseResult = urlparse(url)
 
         if not headers:
             headers = {}
@@ -62,7 +63,7 @@ class Client:  # pylint: disable=too-few-public-methods
         ) as resp:
             try:
                 resp.raise_for_status()
-                data = await resp.json(content_type=None)
+                data: dict = await resp.json(content_type=None)
                 return data
             except client_exceptions.ClientError as err:
                 raise RequestError(f"Error requesting data from {url}: {err}")

--- a/pyiqvia/disease.py
+++ b/pyiqvia/disease.py
@@ -7,7 +7,7 @@ class Disease:  # pylint: disable=too-few-public-methods
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def current(self) -> dict:
         """Get current disease info."""


### PR DESCRIPTION
**Describe what the PR does:**

Now that we can ensure a minimum of Python 3.6, we can use Python 3.6-style type annotations for variables.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
