### PR TITLE
Fix bug with Referer header

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,9 @@ repos:
     hooks:
       - id: codespell
         args:
+          - --ignore-words-list=Referer
           - --skip="./.*,*.json"
-          - --quiet-level=2
+          - --quiet-level=4
         exclude_types: [json]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ repos:
     hooks:
       - id: codespell
         args:
-          - --ignore-words-list=Referer
           - --skip="./.*,*.json"
           - --quiet-level=4
         exclude_types: [json]

--- a/pyiqvia/client.py
+++ b/pyiqvia/client.py
@@ -53,7 +53,7 @@ class Client:  # pylint: disable=too-few-public-methods
         headers.update(
             {
                 "Content-Type": "application/json",
-                "Referrer": f"{pieces.scheme}://{pieces.netloc}",
+                "Referer": f"{pieces.scheme}://{pieces.netloc}",
                 "User-Agent": API_USER_AGENT,
             }
         )


### PR DESCRIPTION
**Describe what the PR does:**

It appears that the IQVIA family of sites _require_ the HTTP 1.0 spelling of the Referrer header (`Referer`). This PR fixes that bug and updates our `pre-commit` `codespell` to ignore it.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/pyiqvia/issues/26
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
