### PR TITLE
Make aiohttp ClientSession optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 data from the [IQVIA™](https://www.iqvia.com) family of websites (such as 
 https://pollen.com, https://flustar.com, and more).
 
+- [Python Versions](#python-versions)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Contributing](#contributing)
+
 # Python Versions
 
 `pyiqvia` is currently supported on:
@@ -28,9 +33,6 @@ pip install pyiqvia
 
 # Usage
 
-`pyiqvia` starts within an
-[aiohttp](https://aiohttp.readthedocs.io/en/stable/) `ClientSession`:
-
 ```python
 import asyncio
 
@@ -40,15 +42,51 @@ from pyiqvia import Client
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-      # YOUR CODE HERE
+    """Run!"""
+    client = Client(80012)
+
+    # ZIP codes starting with 0 need to be provided as strings:
+    client = Client('00544')
+
+    # Get current allergen information:
+    await client.allergens.current()
+
+    # Get more information on the current allergen outlook:
+    await client.allergens.outlook()
+
+    # Get extended forecast allergen information:
+    await client.allergens.extended()
+
+    # Get historic allergen information:
+    await client.allergens.historic()
+
+    # Get current asthma information:
+    await client.asthma.current()
+
+    # Get extended forecast asthma information:
+    await client.asthma.extended()
+
+    # Get historic asthma information:
+    await client.asthma.historic()
+
+    # Get current cold and flu information:
+    await client.disease.current()
+
+    # Get extended forecast cold and flu information:
+    await client.disease.extended()
+
+    # Get historic cold and flu information:
+    await client.disease.historic()
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())
 ```
 
-Create a client and get to it:
+By default, the library creates a new connection to IQVIA with each coroutine. If you
+are calling a large number of coroutines (or merely want to squeeze out every second of
+runtime savings possible), an
+[`aiohttp`](https://github.com/aio-libs/aiohttp) `ClientSession` can be used for connection
+pooling:
 
 ```python
 import asyncio
@@ -59,45 +97,14 @@ from pyiqvia import Client
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-      client = Client(80012, websession)
+    """Run!"""
+    async with ClientSession() as session:
+        client = Client(80012, session=session)
 
-      # ZIP codes starting with 0 need to be provided as strings:
-      client = Client('00544', websession)
-
-      # Get current allergen information:
-      await client.allergens.current()
-
-      # Get more information on the current allergen outlook:
-      await client.allergens.outlook()
-
-      # Get extended forecast allergen information:
-      await client.allergens.extended()
-
-      # Get historic allergen information:
-      await client.allergens.historic()
-
-      # Get current asthma information:
-      await client.asthma.current()
-
-      # Get extended forecast asthma information:
-      await client.asthma.extended()
-
-      # Get historic asthma information:
-      await client.asthma.historic()
-
-      # Get current cold and flu information:
-      await client.disease.current()
-
-      # Get extended forecast cold and flu information:
-      await client.disease.extended()
-
-      # Get historic cold and flu information:
-      await client.disease.historic()
+        # ...
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())
 ```
 
 # Contributing
@@ -106,7 +113,7 @@ asyncio.get_event_loop().run_until_complete(main())
   or [initiate a discussion on one](https://github.com/bachya/pyiqvia/issues/new).
 2. [Fork the repository](https://github.com/bachya/pyiqvia/fork).
 3. (_optional, but highly recommended_) Create a virtual environment: `python3 -m venv .venv`
-4. (_optional, but highly recommended_) Enter the virtual environment: `source ./venv/bin/activate`
+4. (_optional, but highly recommended_) Enter the virtual environment: `source ./.venv/bin/activate`
 5. Install the dev environment: `script/setup`
 6. Code your new feature or bug fix.
 7. Write tests that cover your new functionality.

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -7,38 +7,33 @@ from pyiqvia import Client
 from pyiqvia.errors import IQVIAError
 
 
-async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-        await run(websession)
-
-
-async def run(websession):
+async def main():
     """Run."""
-    try:
-        client = Client("17015", websession)
-        print(f'Client instantiated for ZIP "{client.zip_code}"')
+    async with ClientSession() as session:
+        try:
+            client = Client("17015", session=session)
+            print(f'Client instantiated for ZIP "{client.zip_code}"')
 
-        print()
-        print("Allergen Data:")
-        print(await client.allergens.current())
-        print(await client.allergens.extended())
-        print(await client.allergens.historic())
-        print(await client.allergens.outlook())
+            print()
+            print("Allergen Data:")
+            print(await client.allergens.current())
+            print(await client.allergens.extended())
+            print(await client.allergens.historic())
+            print(await client.allergens.outlook())
 
-        print()
-        print("Disease Data:")
-        print(await client.disease.current())
-        print(await client.disease.extended())
-        print(await client.disease.historic())
+            print()
+            print("Disease Data:")
+            print(await client.disease.current())
+            print(await client.disease.extended())
+            print(await client.disease.historic())
 
-        print()
-        print("Asthma Data:")
-        print(await client.asthma.current())
-        print(await client.asthma.extended())
-        print(await client.asthma.historic())
-    except IQVIAError as err:
-        print(err)
+            print()
+            print("Asthma Data:")
+            print(await client.asthma.current())
+            print(await client.asthma.extended())
+            print(await client.asthma.historic())
+        except IQVIAError as err:
+            print(err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,6 @@ python = "^3.6.0"
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"
 pre-commit = "^2.0.1"
-pytest = "^5.3.5"
+pytest = "^5.4.1"
 pytest-aiohttp = "^0.3.0"
 pytest-cov = "^2.8.1"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,4 @@ aiohttp==3.6.2
 aresponses==1.1.2
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
-pytest==5.3.5
+pytest==5.4.1

--- a/tests/test_allergens.py
+++ b/tests/test_allergens.py
@@ -19,10 +19,27 @@ async def test_current(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(TEST_ZIP, websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
         current = await client.allergens.current()
         assert len(current["Location"]["periods"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_current_no_explicit_session(aresponses):
+    """Test getting current allergen data without an explicit aiohttp ClientSession."""
+    aresponses.add(
+        "www.pollen.com",
+        f"/api/forecast/current/pollen/{TEST_ZIP}",
+        "get",
+        aresponses.Response(
+            text=load_fixture("allergens_current_response.json"), status=200
+        ),
+    )
+
+    client = Client(TEST_ZIP)
+    current = await client.allergens.current()
+    assert len(current["Location"]["periods"]) == 3
 
 
 @pytest.mark.asyncio
@@ -37,8 +54,8 @@ async def test_extended(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(TEST_ZIP, websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
         extended = await client.allergens.extended()
         assert len(extended["Location"]["periods"]) == 5
 
@@ -55,8 +72,8 @@ async def test_historic(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(TEST_ZIP, websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
         historic = await client.allergens.historic()
         assert len(historic["Location"]["periods"]) == 30
 
@@ -73,7 +90,7 @@ async def test_outlook(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(TEST_ZIP, websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
         outlook = await client.allergens.outlook()
         assert outlook["Trend"] == "subsiding"

--- a/tests/test_asthma.py
+++ b/tests/test_asthma.py
@@ -19,8 +19,8 @@ async def test_current(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(TEST_ZIP, websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
         current = await client.asthma.current()
         assert len(current["Location"]["periods"]) == 3
 
@@ -37,8 +37,8 @@ async def test_extended(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(TEST_ZIP, websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
         extended = await client.asthma.extended()
         assert len(extended["Location"]["periods"]) == 5
 
@@ -55,7 +55,7 @@ async def test_endpoints(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(TEST_ZIP, websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
         historic = await client.asthma.historic()
         assert len(historic["Location"]["periods"]) == 30

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,8 +11,8 @@ from .common import TEST_BAD_ZIP, TEST_ZIP
 @pytest.mark.asyncio
 async def test_create():
     """Test the creation of a client."""
-    async with aiohttp.ClientSession() as websession:
-        client = Client(TEST_ZIP, websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
         assert client.zip_code == TEST_ZIP
 
 
@@ -20,8 +20,8 @@ async def test_create():
 async def test_bad_zip():
     """Test attempting to create a client with a bad ZIP code."""
     with pytest.raises(InvalidZipError):
-        async with aiohttp.ClientSession() as websession:
-            _ = Client(TEST_BAD_ZIP, websession)
+        async with aiohttp.ClientSession() as session:
+            _ = Client(TEST_BAD_ZIP, session=session)
 
 
 @pytest.mark.asyncio
@@ -41,7 +41,7 @@ async def test_request_error(aresponses):
     )
 
     with pytest.raises(RequestError):
-        async with aiohttp.ClientSession() as websession:
-            client = Client(TEST_ZIP, websession)
+        async with aiohttp.ClientSession() as session:
+            client = Client(TEST_ZIP, session=session)
             await client._request("get", "https://www.pollen.com/api/bad_endpoint")
             await client.allergens.outlook()

--- a/tests/test_disease.py
+++ b/tests/test_disease.py
@@ -19,8 +19,8 @@ async def test_current(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(TEST_ZIP, websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
         current = await client.disease.current()
         assert len(current["Location"]["periods"]) == 2
 
@@ -37,8 +37,8 @@ async def test_extended(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(TEST_ZIP, websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
         extended = await client.disease.extended()
         assert len(extended["Location"]["periods"]) == 4
 
@@ -55,7 +55,7 @@ async def test_historic(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(TEST_ZIP, websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
         historic = await client.disease.historic()
         assert len(historic["Location"]["periods"]) == 26


### PR DESCRIPTION
**Describe what the PR does:**

This PR makes the `aiohttp` `ClientSession` an optional parameter when creating an API object.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
