### PR TITLE
Fix SSL cert validation error with Flustar

### DIFF
--- a/pyiqvia/disease.py
+++ b/pyiqvia/disease.py
@@ -12,7 +12,7 @@ class Disease:  # pylint: disable=too-few-public-methods
     async def current(self) -> dict:
         """Get current disease info."""
         return await self._request(
-            "get", "https://www.flustar.com/api/forecast/current/cold"
+            "get", "https://flustar.com/api/forecast/current/cold"
         )
 
     async def extended(self) -> dict:
@@ -24,5 +24,5 @@ class Disease:  # pylint: disable=too-few-public-methods
     async def historic(self) -> dict:
         """Get historic disease info."""
         return await self._request(
-            "get", "https://www.flustar.com/api/forecast/historic/cold"
+            "get", "https://flustar.com/api/forecast/historic/cold"
         )

--- a/tests/test_disease.py
+++ b/tests/test_disease.py
@@ -11,7 +11,7 @@ from .common import TEST_ZIP, load_fixture
 async def test_current(aresponses):
     """Test getting current cold and flu data."""
     aresponses.add(
-        "www.flustar.com",
+        "flustar.com",
         f"/api/forecast/current/cold/{TEST_ZIP}",
         "get",
         aresponses.Response(
@@ -47,7 +47,7 @@ async def test_extended(aresponses):
 async def test_historic(aresponses):
     """Test getting historic cold and flu data."""
     aresponses.add(
-        "www.flustar.com",
+        "flustar.com",
         f"/api/forecast/historic/cold/{TEST_ZIP}",
         "get",
         aresponses.Response(


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes an SSL cert validation error related to some `disease` endpoints – basically, we were querying `www.flustar.com` and the cert is now only valid for `flustar.com`.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/pyiqvia/issues/37
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
