### PR TITLE
Remove official support for Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ https://pollen.com, https://flustar.com, and more).
 
 `pyiqvia` is currently supported on:
 
-* Python 3.6
-* Python 3.7
 * Python 3.8
 * Python 3.9
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -39,7 +37,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 aiohttp = "^3.7.4"
-python = "^3.6.0"
+python = "^3.8.0"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"


### PR DESCRIPTION
**Describe what the PR does:**

In preparation for some upcoming features that require a minimum Python version of 3.8, this PR removes official support for 3.6 and 3.7.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
