### PR TITLE
Move request backoff from constant delay to exponential delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ asyncio.run(main())
 
 ## Retries
 
-By default, `pyopenuv` will retry appropriate errors 3 times (with an interval of 3 seconds
-in-between). This logic can be changed by passing different values for `request_retries`
-and `request_retry_interval` to the `Client` constructor:
+By default, `pyiqvia` will retry appropriate errors 4 times (with an exponentially
+increasing delay in-between). This logic can be changed by passing a different value for
+`request_retries` to the `Client` constructor:
 
 ```python
 import asyncio
@@ -92,7 +92,7 @@ from pyiqvia import Client
 
 
 async def main():
-    client = Client("80012", request_retries=5, request_retry_interval=10)
+    client = Client("80012", request_retries=5)
 
     # ...
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,9 +39,7 @@ async def test_http_error(aresponses):
 
     with pytest.raises(RequestError):
         async with aiohttp.ClientSession() as session:
-            client = Client(
-                TEST_ZIP, session=session, request_retries=1, request_retry_interval=0
-            )
+            client = Client(TEST_ZIP, session=session, request_retries=1)
             await client.allergens.outlook()
 
 
@@ -52,9 +50,7 @@ async def test_request_timeout():
         "aiohttp.ClientSession.request", side_effect=asyncio.exceptions.TimeoutError
     ), pytest.raises(RequestError):
         async with aiohttp.ClientSession() as session:
-            client = Client(
-                TEST_ZIP, session=session, request_retries=1, request_retry_interval=0
-            )
+            client = Client(TEST_ZIP, session=session, request_retries=1)
             await client.allergens.outlook()
 
 
@@ -79,7 +75,5 @@ async def test_request_retry(aresponses):
     )
 
     async with aiohttp.ClientSession() as session:
-        client = Client(
-            TEST_ZIP, session=session, request_retries=2, request_retry_interval=0
-        )
+        client = Client(TEST_ZIP, session=session)
         await client.allergens.outlook()


### PR DESCRIPTION
**Describe what the PR does:**

This PR migrates the request backoff delay logic from constant to exponential.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
