### PR TITLE
Allow passing a custom logger to the Client

### DIFF
--- a/pyiqvia/const.py
+++ b/pyiqvia/const.py
@@ -1,4 +1,0 @@
-"""Add package constants."""
-import logging
-
-LOGGER = logging.getLogger(__package__)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,6 +28,7 @@ async def test_bad_zip():
             _ = Client(TEST_BAD_ZIP, session=session)
 
 
+@pytest.mark.asyncio
 async def test_custom_logger(aresponses, caplog):
     """Test that a custom logger is used when provided to the client."""
     caplog.set_level(logging.DEBUG)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,19 +13,19 @@ from .common import TEST_BAD_ZIP, TEST_ZIP, load_fixture
 
 
 @pytest.mark.asyncio
-async def test_create():
-    """Test the creation of a client."""
-    async with aiohttp.ClientSession() as session:
-        client = Client(TEST_ZIP, session=session)
-        assert client.zip_code == TEST_ZIP
-
-
-@pytest.mark.asyncio
 async def test_bad_zip():
     """Test creating a client with a bad ZIP code."""
     with pytest.raises(InvalidZipError):
         async with aiohttp.ClientSession() as session:
             _ = Client(TEST_BAD_ZIP, session=session)
+
+
+@pytest.mark.asyncio
+async def test_create():
+    """Test the creation of a client."""
+    async with aiohttp.ClientSession() as session:
+        client = Client(TEST_ZIP, session=session)
+        assert client.zip_code == TEST_ZIP
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

`backoff` produces its own log messages, which can be confusing when someone is trying to view logs for this application. Since `backoff` allows for the inclusion of a custom logger, we should do the same so that logs can flow through. This PR accomplishes that.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
