### PR TITLE
Add ability to disable and enable retry logic

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,9 @@
+[report]
+exclude_lines =
+    # Don't complain if tests don't hit defensive assertion code:
+    raise NotImplementedError
+    # Don't include lines that are specifically in place for type-checking:
+    TYPE_CHECKING
+
 [run]
 source = pyiqvia

--- a/pyiqvia/allergens.py
+++ b/pyiqvia/allergens.py
@@ -1,34 +1,37 @@
 """Define an object to work with allergy endpoints."""
-from typing import Any, Awaitable, Callable, Dict
+from typing import TYPE_CHECKING, Any, Dict
+
+if TYPE_CHECKING:
+    from .client import Client
 
 
 class Allergens:
     """Define the "Allergens" object."""
 
-    def __init__(self, async_request: Callable[..., Awaitable[Dict[str, Any]]]) -> None:
+    def __init__(self, client: "Client") -> None:
         """Initialize."""
-        self._async_request = async_request
+        self._client = client
 
     async def current(self) -> Dict[str, Any]:
         """Get current allergy conditions."""
-        return await self._async_request(
+        return await self._client.async_request(
             "get", "https://www.pollen.com/api/forecast/current/pollen"
         )
 
     async def extended(self) -> Dict[str, Any]:
         """Get extended allergen info."""
-        return await self._async_request(
+        return await self._client.async_request(
             "get", "https://www.pollen.com/api/forecast/extended/pollen"
         )
 
     async def historic(self) -> Dict[str, Any]:
         """Get historic allergen info."""
-        return await self._async_request(
+        return await self._client.async_request(
             "get", "https://www.pollen.com/api/forecast/historic/pollen"
         )
 
     async def outlook(self) -> Dict[str, Any]:
         """Get allergen outlook."""
-        return await self._async_request(
+        return await self._client.async_request(
             "get", "https://www.pollen.com/api/forecast/outlook"
         )

--- a/pyiqvia/asthma.py
+++ b/pyiqvia/asthma.py
@@ -1,28 +1,31 @@
 """Define an object to work with asthma endpoints."""
-from typing import Any, Awaitable, Callable, Dict
+from typing import TYPE_CHECKING, Any, Dict
+
+if TYPE_CHECKING:
+    from .client import Client
 
 
 class Asthma:
     """Define the "Asthma" object."""
 
-    def __init__(self, async_request: Callable[..., Awaitable[Dict[str, Any]]]) -> None:
+    def __init__(self, client: "Client") -> None:
         """Initialize."""
-        self._async_request = async_request
+        self._client = client
 
     async def current(self) -> Dict[str, Any]:
         """Get current asthma info."""
-        return await self._async_request(
+        return await self._client.async_request(
             "get", "https://www.asthmaforecast.com/api/forecast/current/asthma"
         )
 
     async def extended(self) -> Dict[str, Any]:
         """Get extended asthma info."""
-        return await self._async_request(
+        return await self._client.async_request(
             "get", "https://www.asthmaforecast.com/api/forecast/extended/asthma"
         )
 
     async def historic(self) -> Dict[str, Any]:
         """Get historic asthma info."""
-        return await self._async_request(
+        return await self._client.async_request(
             "get", "https://www.asthmaforecast.com/api/forecast/historic/asthma"
         )

--- a/pyiqvia/disease.py
+++ b/pyiqvia/disease.py
@@ -1,28 +1,31 @@
 """Define an object to work with disease endpoints."""
-from typing import Any, Awaitable, Callable, Dict
+from typing import TYPE_CHECKING, Any, Dict
+
+if TYPE_CHECKING:
+    from .client import Client
 
 
 class Disease:
     """Define the "Disease" object."""
 
-    def __init__(self, async_request: Callable[..., Awaitable[Dict[str, Any]]]) -> None:
+    def __init__(self, client: "Client") -> None:
         """Initialize."""
-        self._async_request = async_request
+        self._client = client
 
     async def current(self) -> Dict[str, Any]:
         """Get current disease info."""
-        return await self._async_request(
+        return await self._client.async_request(
             "get", "https://flustar.com/api/forecast/current/cold"
         )
 
     async def extended(self) -> Dict[str, Any]:
         """Get extended disease info."""
-        return await self._async_request(
+        return await self._client.async_request(
             "get", "https://www.pollen.com/api/forecast/extended/cold"
         )
 
     async def historic(self) -> Dict[str, Any]:
         """Get historic disease info."""
-        return await self._async_request(
+        return await self._client.async_request(
             "get", "https://flustar.com/api/forecast/historic/cold"
         )

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.7.4post0
-aresponses==1.1.2
+aresponses==2.0.0
 backoff==1.11.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds two new methods to the client object:

* `disable_request_retries()`
* `enable_request_retries()`

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
